### PR TITLE
FEAT: frontend add DOMAIN & docker compose image/container name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,10 +3,14 @@ version: "3.8"
 services:
   nginx:
     build: ./nginx
+    image: "frontend:pong-beat-makers"
+    container_name: "frontend"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/conf.d/:/etc/nginx/conf.d
       - ./frontend:/usr/share/nginx/html
+    env_file:
+      - ./env/user-management.env
     ports:
       - 443:443
     depends_on:
@@ -17,6 +21,8 @@ services:
 
   chatting:
     build: ./chatting
+    image: "chatting:pong-beat-makers"
+    container_name: "chatting"
     env_file:
       - ./env/chatting.env
     depends_on:
@@ -26,6 +32,7 @@ services:
 
   chatting_db:
     image: "postgres:16.2-alpine3.18"
+    container_name: "chatting-db"
     env_file:
       - ./env/chatting_db.env
     healthcheck:
@@ -35,6 +42,8 @@ services:
 
   game:
     build: ./game
+    image: "game:pong-beat-makers"
+    container_name: "game"
     env_file:
       - ./env/game.env
     depends_on:
@@ -44,6 +53,7 @@ services:
 
   game_db:
     image: "postgres:16.2-alpine3.18"
+    container_name: "game-db"
     env_file:
       - ./env/game_db.env
     healthcheck:
@@ -53,6 +63,8 @@ services:
 
   user-management:
     build: ./user-management
+    image: "user-management:pong-beat-makers"
+    container_name: "user-management"
     env_file:
       - ./env/user-management.env
     depends_on:
@@ -62,6 +74,7 @@ services:
 
   user-management_db:
     image: "postgres:16.2-alpine3.18"
+    container_name: "user-management-db"
     env_file:
       - ./env/user-management_db.env
     healthcheck:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,9 +1,10 @@
 FROM nginx:stable-alpine
 
-RUN apk add openssl
+RUN apk add openssl gettext
 
 WORKDIR /app
 
 COPY ./docker-entrypoint.sh ./docker-entrypoint.sh
+COPY ./global.js ./global.js
 
 CMD ["/bin/sh", "docker-entrypoint.sh"]

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -5,4 +5,6 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
     && chown root:root /etc/ssl/private/nginx-key.pem \
     && chmod 600 /etc/ssl/private/nginx-key.pem
 
+envsubst < ./global.js > /usr/share/nginx/html/src/Public/global.js
+
 nginx -g 'daemon off;'

--- a/nginx/global.js
+++ b/nginx/global.js
@@ -1,0 +1,20 @@
+const domain = '${DOMAIN}';
+const https = 'https://';
+const wss = 'wss://';
+
+export const FRONTEND = https + domain;
+export const BACKEND = https + domain;;
+
+// Servers
+export const USER_SERVER_DOMAIN = https + domain;
+export const CHAT_SERVER_DOMAIN = https + domain;
+export const GAME_SERVER_DOMAIN = https + domain;
+
+// Domains
+export const USER_MANAGEMENT_DOMAIN = 'api/user-management';
+export const CHAT_API_DOMAIN = 'api/chatting';
+export const GAME_API_DOMAIN = 'api/game';
+
+// Chatting
+export const CHAT_WEBSOCKET = wss + domain;
+export const GAME_WEBSOCKET = wss + domain;


### PR DESCRIPTION
## Frontend DOMAIN
- [x] frontend에서 `global.js`에 도메인 주소를 `user_management.env`의 `DOMAIN`에 맞춰 수정됩니다!
  + 추가된 파일 `global.js` (global.js의 탬플릿이라고 보면 됩니다.)
  + nginx/Dockerfile
    ```Dockerfile
    RUN apk add openssl gettext        // gettext 추가 설치

    COPY ./global.js ./global.js       // global.js 템플릿 복사 ( 루트 디렉토리에 복사합니다)
    ```
- [x] add docker image/container name
- [x] user-management 최신 버전 반영